### PR TITLE
Refactor rate limiter to use BotVerifier service & add BotVerifierTest

### DIFF
--- a/app/Services/BotVerifier.php
+++ b/app/Services/BotVerifier.php
@@ -4,21 +4,54 @@ namespace App\Services;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-
+use Illuminate\Cache\RateLimiting\Limit;
 
 class BotVerifier
 {
-    public function isVerifiedBot(Request $request, string $expectedDomain): bool
+    protected DnsResolverInterface $dnsResolver;
+
+    public function __construct(DnsResolverInterface $dnsResolver)
+    {
+        $this->dnsResolver = $dnsResolver;
+    }
+
+    protected function isVerifiedBot(Request $request, string $expectedDomain): bool
     {
         $ip = $request->ip();
 
-        $hostname = Cache::remember("hostname:$ip", 300, fn() => gethostbyaddr($ip));;
-        if (!$hostname || !str_ends_with($hostname, $expectedDomain)) {
+        $hostname = Cache::remember("hostname:$ip", 300, fn() => $this->dnsResolver->reverseDns($ip));
+        if (!$hostname || !str_ends_with(strtolower($hostname), strtolower($expectedDomain))) {
             return false;
         }
 
-        // Forward DNS check to validate hostname resolves back to IP
-        $resolvedIp = gethostbyname($hostname);
+        $resolvedIp = $this->dnsResolver->forwardDns($hostname);
         return $resolvedIp === $ip;
+    }
+
+    public function resolveBotOrTrustedLimit(Request $request): ?Limit
+    {
+
+        $trustedIps = array_filter(config('trusted.ips', []));
+        if (in_array($request->ip(), $trustedIps)) {
+            return Limit::none();
+        }
+
+        $bots = [
+            'googlebot' => '.googlebot.com',
+            'bingbot' => '.search.msn.com',
+            'yandexbot' => '.yandex.ru',
+            'applebot' => '.applebot.apple.com',
+        ];
+
+        $ip = $request->ip();
+        $ua = strtolower($request->userAgent() ?? '');
+
+        foreach ($bots as $keyword => $domain) {
+            if (str_contains($ua, $keyword) && $this->isVerifiedBot($request, $domain)) {
+                return Limit::perMinute(300)->by($ip);
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Services/DnsResolverInterface.php
+++ b/app/Services/DnsResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Services;
+
+interface DnsResolverInterface
+{
+    public function reverseDns(string $ip): ?string;
+    public function forwardDns(string $hostname): ?string;
+}

--- a/app/Services/PhpDnsResolver.php
+++ b/app/Services/PhpDnsResolver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Services;
+
+class PhpDnsResolver implements DnsResolverInterface
+{
+    public function reverseDns(string $ip): ?string
+    {
+        return gethostbyaddr($ip) ?: null;
+    }
+
+    public function forwardDns(string $hostname): ?string
+    {
+        return gethostbyname($hostname) ?: null;
+    }
+}

--- a/config/trusted.php
+++ b/config/trusted.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'ips' => explode(',', env('TRUSTED_IPS', '')),
+];

--- a/tests/Feature/BotVerifierTest.php
+++ b/tests/Feature/BotVerifierTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Cache\RateLimiting\Limit;
+use App\Services\BotVerifier;
+use App\Services\DnsResolverInterface;
+use Illuminate\Support\Facades\Config;
+use Mockery;
+
+class BotVerifierTest extends TestCase
+{
+    protected function mockRequest(string $ip, string $userAgent): Request
+    {
+        $request = Request::create('/', 'GET');
+        $request->server->set('REMOTE_ADDR', $ip);
+        $request->headers->set('User-Agent', $userAgent);
+        return $request;
+    }
+
+    public function test_trusted_ip_returns_unlimited_limit()
+    {
+        Config::set('trusted.ips', ['1.2.3.4']);
+
+        $request = $this->mockRequest('1.2.3.4', 'Some User Agent');
+
+        // DNS resolver mock with no calls expected for trusted IPs
+        $dnsResolver = Mockery::mock(DnsResolverInterface::class);
+        $dnsResolver->shouldNotReceive('reverseDns');
+        $dnsResolver->shouldNotReceive('forwardDns');
+
+        $verifier = new BotVerifier($dnsResolver);
+
+        $limit = $verifier->resolveBotOrTrustedLimit($request);
+
+        $this->assertInstanceOf(Limit::class, $limit);
+        $this->assertEquals(PHP_INT_MAX, $limit->maxAttempts);
+    }
+
+    public function test_untrusted_bot_not_verified_returns_null()
+    {
+        Config::set('trusted.ips', []);
+
+        // DO NOT mock Cache::remember here; let it run normally
+
+        $request = $this->mockRequest('8.8.8.8', 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)');
+
+        $dnsResolver = Mockery::mock(DnsResolverInterface::class);
+        $dnsResolver->shouldReceive('reverseDns')->once()->andReturn('something.invalid.com');
+        $dnsResolver->shouldReceive('forwardDns')->never();
+
+        $verifier = new BotVerifier($dnsResolver);
+
+        $limit = $verifier->resolveBotOrTrustedLimit($request);
+
+        $this->assertNull($limit);
+    }
+
+    public function test_verified_bot_returns_high_limit()
+    {
+        Config::set('trusted.ips', []);
+
+        // DO NOT mock Cache::remember here either
+
+        $request = $this->mockRequest('66.249.66.1', 'Googlebot/2.1');
+
+        $dnsResolver = Mockery::mock(DnsResolverInterface::class);
+        $dnsResolver->shouldReceive('reverseDns')->once()->andReturn('crawl-66-249-66-1.googlebot.com');
+        $dnsResolver->shouldReceive('forwardDns')->once()->andReturn('66.249.66.1');
+
+        $verifier = new BotVerifier($dnsResolver);
+
+        $limit = $verifier->resolveBotOrTrustedLimit($request);
+
+        $this->assertInstanceOf(Limit::class, $limit);
+        $this->assertEquals(300, $limit->maxAttempts);
+    }
+
+    public function test_normal_user_returns_null()
+    {
+        Config::set('trusted.ips', []);
+
+        $request = $this->mockRequest('9.9.9.9', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)');
+
+        // No DNS calls expected
+        $dnsResolver = Mockery::mock(DnsResolverInterface::class);
+        $dnsResolver->shouldNotReceive('reverseDns');
+        $dnsResolver->shouldNotReceive('forwardDns');
+
+        $verifier = new BotVerifier($dnsResolver);
+
+        $limit = $verifier->resolveBotOrTrustedLimit($request);
+
+        $this->assertNull($limit);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Refactor rate limiter to use BotVerifier service for trusted IPs and bots and add BotVerifierTest

- Bind DnsResolverInterface to PhpDnsResolver in AppServiceProvider
- Replace inline trusted IP and bot checks in RateLimiter definitions with BotVerifier calls
- Move bot verification logic into BotVerifier::resolveBotOrTrustedLimit()
- Improve case-insensitive hostname checks and use dependency-injected DNS resolver
- Add BotVerifierTest
