### PR TITLE
feat: allow voting with upvote/downvote toggle and removal via single…

### DIFF
--- a/app/Http/Controllers/VoteController.php
+++ b/app/Http/Controllers/VoteController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+use App\Services\VoteService;
+use Illuminate\Http\JsonResponse;
+use App\Http\Requests\VoteRequest;
+use Symfony\Component\HttpFoundation\Response;
+
+
+class VoteController extends Controller
+{
+    public function __construct(protected VoteService $voteService) {}
+
+
+    /**
+     * Submit a vote on a post (upvote or downvote).
+     *
+     * Sends a vote for the specified post. The vote can be either an upvote or a downvote,
+     * determined by the `is_upvote` boolean value.
+     *
+     * @group Votes
+     * @authenticated
+     *
+     * @urlParam post string required The UUID of the post.
+     * @bodyParam is_upvote boolean required Whether the vote is an upvote (true) or downvote (false). Example: true
+     *
+     * @response 200 {
+     *   "message": "Vote registered."
+     * }
+     */
+    public function vote(Post $post, VoteRequest $request): JsonResponse
+    {
+        $this->voteService->vote($request->user(), $post, $request->boolean('is_upvote'));
+
+        return response()->json(['message' => 'Vote registered.'], Response::HTTP_OK);
+    }
+
+
+    /**
+     * Remove vote from a post.
+     *
+     * Removes the user's existing vote (upvote or downvote) from the post.
+     *
+     * @group Votes
+     * @authenticated
+     *
+     * @urlParam post string required The UUID of the post.
+     *
+     * @response 200 {
+     *   "message": "Vote removed."
+     * }
+     */
+    public function removeVote(Post $post, Request $request): JsonResponse
+    {
+        $this->voteService->removeVote($request->user(), $post);
+
+        return response()->json(['message' => 'Vote removed.'], Response::HTTP_OK);
+    }
+}

--- a/app/Http/Requests/VoteRequest.php
+++ b/app/Http/Requests/VoteRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VoteRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'is_upvote' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Resources/PostResource.php
+++ b/app/Http/Resources/PostResource.php
@@ -10,25 +10,28 @@ class PostResource extends JsonResource
 {
     public function toArray(Request $request): array
     {
-        // Make sure meta is always an array
-        $meta = $this->meta ?? [];
-
-        // Override or set 'tags' inside meta from hashtags relation if loaded
-        if ($this->relationLoaded('hashtags')) {
-            $meta['tags'] = $this->hashtags->pluck('name')->toArray();
-        }
-
         return [
             'id' => $this->id,
             'user_id' => $this->user_id,
             'body' => $this->body,
             'external_url' => $this->external_url,
-            'meta' => $meta,
+            'meta' => $this->meta,
             'hashtags' => $this->whenLoaded('hashtags', fn() => $this->hashtags->pluck('name')),
+            'votes' => [
+                'upvotes' => $this->upvotes()->count(),
+                'downvotes' => $this->downvotes()->count(),
+            ],
             'media' => MediaResource::collection($this->whenLoaded('media')),
             'comments'  => CommentResource::collection($this->whenLoaded('comments')),
             'type' => $this->type,
             'user' => new UserResource($this->whenLoaded('user')),
+            'my_vote' => $this->when($request->user(), function () use ($request) {
+                $vote = $this->votes()
+                    ->where('user_id', $request->user()->id)
+                    ->first();
+
+                return $vote ? ($vote->is_upvote ? 'upvote' : 'downvote') : null;
+            }),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -59,4 +59,19 @@ class Post extends Model
             'user_id'
         )->withTimestamps();
     }
+
+    public function votes()
+    {
+        return $this->hasMany(Vote::class);
+    }
+
+    public function upvotes()
+    {
+        return $this->votes()->where('is_upvote', true);
+    }
+
+    public function downvotes()
+    {
+        return $this->votes()->where('is_upvote', false);
+    }
 }

--- a/app/Models/Vote.php
+++ b/app/Models/Vote.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Vote extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string'; // UUID
+
+    protected $fillable = ['id', 'user_id', 'post_id', 'is_upvote'];
+
+    protected $casts = [
+        'is_upvote' => 'boolean',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function post()
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Services/VoteService.php
+++ b/app/Services/VoteService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Vote;
+use Illuminate\Support\Str;
+
+class VoteService
+{
+    public function vote(User $user, Post $post, bool $isUpvote): ?Vote
+    {
+        $existing = Vote::where('user_id', $user->id)
+            ->where('post_id', $post->id)
+            ->first();
+
+        if ($existing) {
+            if ($existing->is_upvote === $isUpvote) {
+                // Same vote again = remove (toggle off)
+                $existing->delete();
+                return null;
+            }
+
+            // Change direction
+            $existing->is_upvote = $isUpvote;
+            $existing->save();
+            return $existing;
+        }
+
+        return Vote::create([
+            'id' => Str::uuid(),
+            'user_id' => $user->id,
+            'post_id' => $post->id,
+            'is_upvote' => $isUpvote,
+        ]);
+    }
+
+    public function removeVote(User $user, Post $post): void
+    {
+        Vote::where('user_id', $user->id)
+            ->where('post_id', $post->id)
+            ->delete();
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PostController;
 use App\Http\Controllers\SaveController;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\VoteController;
 use App\Http\Controllers\BlockController;
 use App\Http\Controllers\MediaController;
 use App\Http\Controllers\FollowController;
@@ -63,5 +64,8 @@ Route::middleware(['api', 'throttle:api'])->group(function () {
         Route::get('/saved-posts', [SaveController::class, 'index']);
         Route::post('/posts/{post}/save', [SaveController::class, 'save']);
         Route::delete('/posts/{post}/unsave', [SaveController::class, 'unsave']);
+        // Vote endpoints
+        Route::post('/posts/{post}/vote', [VoteController::class, 'vote']);
+        Route::delete('/posts/{post}/vote', [VoteController::class, 'removeVote']);
     });
 });

--- a/tests/Feature/VoteTest.php
+++ b/tests/Feature/VoteTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Post;
+use App\Models\Vote;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class VoteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected Post $post;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->post = Post::factory()->create();
+    }
+
+    public function test_user_can_upvote_a_post(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => true,
+        ]);
+        $response->assertOk();
+        $this->assertDatabaseHas('votes', [
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'is_upvote' => true,
+        ]);
+    }
+
+    public function test_user_can_downvote_a_post(): void
+    {
+        $this->actingAs($this->user);
+
+        $response = $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => false,
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('votes', [
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'is_upvote' => false,
+        ]);
+    }
+
+    public function test_user_can_toggle_vote_off_by_voting_same_again(): void
+    {
+        $this->actingAs($this->user);
+
+        // First upvote
+        $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => true,
+        ]);
+
+        // Same upvote again = toggle off
+        $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => true,
+        ]);
+
+        $this->assertDatabaseMissing('votes', [
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+        ]);
+    }
+
+    public function test_user_can_change_vote_direction(): void
+    {
+        $this->actingAs($this->user);
+
+        // First upvote
+        $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => true,
+        ]);
+
+        // Change to downvote
+        $this->postJson("/api/posts/{$this->post->id}/vote", [
+            'is_upvote' => false,
+        ]);
+
+        $this->assertDatabaseHas('votes', [
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'is_upvote' => false,
+        ]);
+
+        $this->assertDatabaseCount('votes', 1); // still only one vote
+    }
+
+    public function test_only_one_vote_record_per_user_post(): void
+    {
+        $this->actingAs($this->user);
+
+        $this->postJson("/api/posts/{$this->post->id}/vote", ['is_upvote' => true]);
+        $this->postJson("/api/posts/{$this->post->id}/vote", ['is_upvote' => false]);
+
+        $this->assertEquals(1, Vote::where('user_id', $this->user->id)->where('post_id', $this->post->id)->count());
+    }
+}


### PR DESCRIPTION
### feat: unify upvote/downvote logic into single endpoint using `is_upvote` flag

- Accepts `is_upvote` as a boolean in the request body
- Enables users to toggle votes (upvote ↔ downvote)
- Allows vote removal by sending the same vote twice
- Simplifies vote handling and improves UX